### PR TITLE
Check the rails env even when running in a non-rails session. 

### DIFF
--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -62,6 +62,8 @@ module Multidb
           @fallback = @configuration.raw_configuration[:fallback]
         elsif defined?(Rails)
           @fallback = %w(development test).include?(Rails.env)
+        elsif ENV['RAILS_ENV'].present?
+          @fallback = %w(development test).include?(ENV['RAILS_ENV'])
         else
           @fallback = false
         end


### PR DESCRIPTION
The balancer currently this just checks `Rails.env` but that doesn't work on cube-workers, so also check the `RAILS_ENV` environment variable if it exists.

The reason I ran into this is because a cube worker handler was running `results_for_all_shards` and getting back an exception that `db1` was not defined. 